### PR TITLE
Stream to output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Online Feature Serivce Layers to GeoJSON
+# ArcGIS Online Feature Service Layers to GeoJSON
 
 **Work in progress, pull requests welcome!**
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ cache.featureServiceToGeoJSON(urls[0], {
     layerByLayer: false, //use await on each layer, helpful for debugging
     prefix: "", //prefix to add to the start of layer names
     silent: true, //turn off viewing log messages in the console, disabled if debug is set to false, however spinner is always on
-    token: null //token to use for secured routes, taken from .env TOKEN variable
+    token: null, //token to use for secured routes, taken from .env TOKEN variable
+    pretty: false //if true, the JSON output file will be formatted for human reading
 })
 ```
 ## .env file example

--- a/lib/featureServiceToGeoJSON.js
+++ b/lib/featureServiceToGeoJSON.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const spinner = require('ora')();
 const env = require('dotenv').config().parsed;
 const winston = require('winston');
+const { Transform } = require('stream');
 
 // if (fs.existsSync("agol-cache.log")) fs.unlinkSync("agol-cache.log")
 
@@ -49,8 +50,8 @@ const _fetch = require("node-fetch");
 const fetch = require("fetch-retry")(_fetch, {
   retryOn: function (attempt, error, response) {
     if (attempt < 5 && error) {
-      spinner.text = `Retry attempt ${attempt}`;
-      logger.error(`Retry attempt ${attempt} ${JSON.stringify(error)}`)
+      spinner.text = `Retry attempt ${attempt + 1}`;
+      logger.error(`Retry attempt ${attempt + 1} ${JSON.stringify(error)}`)
       return true
     }
     return false
@@ -75,20 +76,21 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
 
   const config = {
     attachments: (!options || !options.attachments) ? false : true, //wheher or not to check the service for attachments, overridden by leaving esriIdField blank
-    debug: (!options || !options.debug) ? false : true, //debugging is now on be default, which just means it writes to a log file, and the console if silent is set to false 
+    debug: (!options || options.debug) ? true : false, //debugging is now on be default, which just means it writes to a log file, and the console if silent is set to false 
     esriIdField: (!options || !options.esriIdField) ? false : options.esriIdField, //field to use for the esriIdField, used in the query parameters
     filter: (!options || !options.filter) ? false : options.filter, //string to filter layer names
     folder: (!options || !options.folder) ? "geojson-cache" : options.folder, //folder to write the log file and geojson cache, relative to working directory or absolute path
     layerByLayer: (!options || !options.layerByLayer) ? false : true, //use await on each layer, helpful for debugging
     prefix: (!options || !options.prefix) ? "" : options.prefix, //prefix to add to the start of layer names
     silent: (options && options.silent) ? true : (options && !options.silent) ? false : true, //turn off viewing log messages in the console, disabled if debug is set to false, however spinner is always on
-    token: (env && env.TOKEN) ? env.TOKEN : null //token to use for secured routes,
+    token: (env && env.TOKEN) ? env.TOKEN : null, //token to use for secured routes,
+    pretty: (!options || !options.pretty) ? false : true, //if true, the JSON output file will be formatted for human reading
   }
 
   /**
    * Set the silent option on the console logger
    */
-  logger.transports.map(transport => {
+  logger.transports.forEach(transport => {
     if (transport.name && transport.name === "console") transport.silent = config.silent;
     if (transport.name && transport.name === "logfile") transport.silent = !config.debug;
   });
@@ -151,13 +153,12 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
             callback(layers)
           }else{
             throw new Error({Error: "callback is not a function"});
-            process.exit();
           }
         }
       }catch(error) {
         spinner.fail("Error on " + l.name);
         spinner.start("Processing");
-        if (config.debug) logger.error(error);
+        if (config.debug) logger.error(error.toString());
         total = total - 1;
         if (!total) {
           if (callback && isFunction(callback)) {
@@ -165,7 +166,6 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
             callback(layers)
           }else{
             throw new Error({Error: "callback is not a function"});
-            process.exit();
           }
         }
         continue
@@ -194,7 +194,7 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
       }catch(error) {
         spinner.fail("Error on Layer " + total.toString());
         spinner.start("Processing")
-        if (config.debug) logger.error(error);
+        if (config.debug) logger.error(error.toString());
         total = total - 1;
         if (!total) {
           spinner.stop();
@@ -220,7 +220,7 @@ async function getFeatureService(serviceURL, opts) {
   }
   catch(error) {
     error["function"] = "getFeatureService"
-    if (opts.debug) logger.error(error)
+    if (opts.debug) logger.error(error.toString())
     return false
   }
 }
@@ -230,7 +230,7 @@ function getLayers(serviceDefinition) {
 
   if (!serviceDefinition.layers || !serviceDefinition.layers.length) return layers
 
-  serviceDefinition.layers.map(l => {
+  serviceDefinition.layers.forEach(l => {
     if (!l.subLayerIds) {
       layers.push({
         id: l.id,
@@ -245,10 +245,100 @@ function convertName(name) {
   return name.toLowerCase().replace(/ /g, '_').replace(/-/g, '_')
 }
 
+/**
+ * Returns a Node.js stream that can be fed in JSON objects and
+ * will stringify them as output.
+ * @param {Object} options - Configuration for the stream processing.
+ * @param {function} options.warnFn - called when an object is not stringify-able JSON.
+ * @param {string} [options.beforeAll] - string to add at the start of the file.
+ * @param {string} [options.afterAll] - string to add at the end of the file.
+ * @param {string} [options.separator=\n] - string after each JSON, defaults to newline.
+ * @param {number|string} [options.indent=0] - number of spaces or text before each JSON line.
+ * @returns {Transform} A Transform stream.
+ */
+function createJsonStream(options) {
+  const beforeAll = options.beforeAll || ''
+  const afterAll = options.afterAll || ''
+  const separator = options.separator || '\n'
+  const indent = options.indent || 0
+
+  let inFeatures = 0
+  let outFeatures = 0
+
+  const stream = new Transform({
+    writableObjectMode: true,  // takes in objects...
+    readableObjectMode: false, // ...and outputs strings.
+
+    transform(chunk, _, callback) {
+      inFeatures += 1;
+      var json;
+      try {
+        json = JSON.stringify(chunk, null, indent)
+      } catch (err) {
+        if (options.warnFn) {
+          options.warnFn(err, inFeatures, chunk);
+        }
+        callback();
+        return;
+      }
+      if (!outFeatures) {
+        this.push(beforeAll + json)
+      }
+      else {
+        this.push(separator + json)
+      }
+      outFeatures += 1;
+      callback();
+    },
+
+    // end of JSON input
+    flush(callback) {
+      if(outFeatures === 0) {
+        this.push(open + afterAll);
+      } else {
+        this.push(afterAll);
+      }
+      callback();
+    }
+
+  });
+
+  return stream;
+}
+
 async function getFeatures(layerUrl, layerName, opts, id) {
   let idFieldObject = [];
   let completed = false
-  let features = [];
+  let hasErrors = false
+  let nbrFeatures = 0;
+
+  const jsonStart = `{"type": "FeatureCollection", "agolLayerId": ${id}, "features": [`;
+
+  const filename = `${opts.prefix}${layerName}`;
+  const filepath = `${opts.folder}/${filename}.geojson`;
+  const outputStream = fs.createWriteStream(filepath);
+
+  // features go to jsonInStream with .write and are piped to outputStream
+  const jsonInStream = createJsonStream({
+    beforeAll: opts.pretty ? jsonStart : jsonStart.replace(/ /g, ''),
+    afterAll: opts.pretty ? '\n]}' : ']}',
+    separator: opts.pretty ? ',\n' : ',',
+    indent: opts.pretty ? 2 : 0,
+    warnFn: (err, row, jsonObject) => {
+      if (opts.debug) logger.warn(`record ${row} of ${layerName} is invalid.`);
+      hasErrors = true;
+    }
+  });
+  jsonInStream.pipe(outputStream);
+  jsonInStream.on('error', (error) => {
+    hasErrors = true
+    if (opts.debug) logger.error(error.toString())
+  });
+
+  var writeDonePromise = new Promise((resolve, reject) => {
+    outputStream.on('finish', resolve);
+    outputStream.on('error', reject);
+  });
 
   // let getAttachments = opts.attachments;
   if (!opts.esriIdField || opts.hasAttachments) {
@@ -279,7 +369,7 @@ async function getFeatures(layerUrl, layerName, opts, id) {
         spinner.start("Processing")
       }
     }catch(error) {
-      if (opts.debug) logger.error(error)
+      if (opts.debug) logger.error(error.toString())
     }
   }
 
@@ -297,46 +387,43 @@ async function getFeatures(layerUrl, layerName, opts, id) {
     try {
       geojson = await queryAGOL(layerUrl, idField, ids.start, ids.end, opts, layerName);
       if (geojson.error) {
-        features = [];
         completed = true
       }
       if (!geojson || !geojson.features || !geojson.features.length) {
         completed = true;
-      }
-
-      if (geojson && geojson.features) {
-        geojson.features.map(f => {
-          features.push(f)
+      } else {
+        geojson.features.forEach(f => {
+          jsonInStream.write(f);
+          nbrFeatures = nbrFeatures + 1;
         });
+        spinner.text = `Processing ${nbrFeatures} features`;
       }
 
       ids.start = ids.start + max + 1;
       ids.end = ids.end + max + 1;
     }
     catch(error) {
-      if (opts.debug) logger.error(`${error}`)
-      features = []
+      if (opts.debug) logger.error(error.toString())
+      hasErrors = true
       completed = true
     }
   }
-
-  const finalGeoJSON = {
-    type: "FeatureCollection",
-    agolLayerId: id,
-    features: features
+  jsonInStream.end(); // signal no more data
+  try {
+    await writeDonePromise; // and wait for everything to finish
+  } catch (error) {
+    hasErrors = true
+    if (opts.debug) logger.error(error.toString())
   }
 
-  if (!features.length) {
-    spinner.warn(`Warning! 0 features found, skipping ${opts.prefix}${layerName}`);
-    if (opts.debug) logger.error(`Warning! 0 features found, skipping ${opts.prefix}${layerName}`)
-    spinner.start("Processing");
-  }else{
-    fs.writeFileSync(`${opts.folder}/${opts.prefix}${layerName}.geojson`, JSON.stringify(finalGeoJSON))
-    spinner.succeed(`Success! Wrote ${Number(finalGeoJSON.features.length)} features to ${opts.prefix}${layerName}.geojson`);
-    if (opts.debug) logger.debug(`Success! Wrote ${Number(finalGeoJSON.features.length)} features to ${opts.prefix}${layerName}.geojson`)
-    spinner.start("Processing")
+  if (hasErrors) {
+    spinner.warn(`Warning! ${nbrFeatures} features found, there were errors with ${filename}`);
+    if (opts.debug) logger.error(`Warning! ${nbrFeatures} features found, there were errors with ${filename}`)
+  } else{
+    spinner.succeed(`Success! Wrote ${nbrFeatures} features to ${filename}.geojson`);
+    if (opts.debug) logger.debug(`Success! Wrote ${nbrFeatures} features to ${filename}.geojson`)
   }
-
+  spinner.start("Processing");
 }
 
 async function queryAGOL(url, idField, start, end, opts, layerName) {
@@ -351,7 +438,7 @@ async function queryAGOL(url, idField, start, end, opts, layerName) {
     return data
   }
   catch(error) {
-    if (opts.debug) logger.error(error);
+    if (opts.debug) logger.error(error.toString());
     data["error"] = true
     return data
   }

--- a/test.js
+++ b/test.js
@@ -18,7 +18,8 @@ cache.featureServiceToGeoJSON(urls[2], {
   layerByLayer: false, //use await on each layer, helpful for debugging
   prefix: "", //prefix to add to the start of layer names
   silent: true, //turn off viewing log messages in the console, disabled if debug is set to false, however spinner is always on
-  token: null //token to use for secured routes, taken from .env TOKEN variable
+  token: null, //token to use for secured routes, taken from .env TOKEN variable
+  pretty: false, //if true, the JSON output file will be formatted for human reading
 }, getAttachments);
 
 function getAttachments() {


### PR DESCRIPTION
Thanks for this project Malcolm. I actually found it before I realized it was you!

I was using this with a very large dataset (Ohio census blocks), with a quarter million polygon records. The size of the dataset was causing the final `JSON.stringify` to fail with the error `Invalid string length`, which seems to be related to the amount of memory available to the Node process.

I made an alteration to the code that uses Node's streams feature to write the JSON to the output file as it's being downloaded, instead of caching to memory and then stringifying and writing at the end.

Here is a test to show it now works:

```Javascript
const cache = require('./lib/featureServiceToGeoJSON');

const url = 'https://services3.arcgis.com/gk1IzaxatNGyH1UK/ArcGIS/rest/services/Ohio_Districts/FeatureServer';
cache.featureServiceToGeoJSON(url, { folder: './output' }, (layers) => {
  console.log('done');
  console.log('output ' + layers.length + ' layers')
});
```

I also made some other minor edits:

- Make "Retry attempt X" text begin at 1 instead of 0.
- The config documentation says that "debugging is now on be default", but the logic has `debug` as `false` by default, so I flipped the logic.
- Add a `pretty` option that will make the output file human readable if desired (defaults to false).
- Use `.forEach` instead of `.map` for looping over arrays.
- The `logger.error(error)` calls were outputting "unknown", I changed them to `logger.error(error.toString())`
