### PR TITLE
More tests and error handling

### DIFF
--- a/lib/featureServiceToGeoJSON.js
+++ b/lib/featureServiceToGeoJSON.js
@@ -78,15 +78,17 @@ const fetch = require("fetch-retry")(require("node-fetch"), {
  * @param {function} callback
  */
 async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
-  const Gdal = await initGdalJs();
   const Formats = [];
   const formats = [];
-  Object.values(Gdal.drivers.vector).forEach((driver) => {
-    if (driver.isWritable) {
-      formats.push(driver.shortName.toLowerCase());
-      Formats.push(driver.shortName);
-    }
-  });
+  if (options && options.outputFormat) {
+    const Gdal = await initGdalJs();
+    Object.values(Gdal.drivers.vector).forEach((driver) => {
+      if (driver.isWritable) {
+        formats.push(driver.shortName.toLowerCase());
+        Formats.push(driver.shortName);
+      }
+    });
+  }
 
   if (featureServiceUrl.charAt(featureServiceUrl.length - 1) != "/")
     featureServiceUrl = featureServiceUrl + "/";
@@ -158,10 +160,10 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
   const service = await getFeatureService(featureServiceUrl, config);
 
   if (service.error) {
-    let msg = "Could not find feature service definition!";
+    let msg = `Could not find feature service definition: ${service.error}`;
     spinner.fail(msg);
     logger.error(service.error);
-    return null;
+    throw new Error(msg);
   }
 
   const layers = getLayers(service);
@@ -207,7 +209,7 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
     if (!total) {
       spinner.fail("Fatal error, no layers found!");
       logger.error("Fatal error,  no layers found.");
-      return [];
+      return { layers: [], tables: [] };
     }
 
     if (!config.silent) spinner.succeed("Layers found: " + layers.length).start();
@@ -231,7 +233,7 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
           throw new Error("Missing feature count!");
         }
 
-        layers[i]["count"] = count;
+        l["count"] = count;
 
         if (!config.silent) spinner.info(l?.name + " total features: " + count);
 
@@ -263,7 +265,7 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
             logger.info("total " + total);
           }
 
-          await getFeatures(
+          const fetchResult = await getFeatures(
             `${featureServiceUrl}${l.id}/`,
             l.name,
             config,
@@ -273,6 +275,9 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
             l.domainFields,
             layers
           );
+          l["nbrFeatures"] = fetchResult.nbrFeatures;
+          l["nbrErrors"] = fetchResult.featuresWithError;
+          l["exampleErrors"] = fetchResult.exampleErrors;
           total = total - 1;
           if (!total) {
             spinner.stop();
@@ -289,7 +294,7 @@ async function featureServiceToGeoJSON(featureServiceUrl, options, callback) {
           }
         } catch (error) {
           spinner.fail("Error");
-          logger.error(error.toString());
+          logger.error("Failed to query " + l.name, { error });
           if (!config.silent) spinner.start("Querying: " + l.name);
           total = total - 1;
           if (!total) {
@@ -556,8 +561,7 @@ async function getFeatureService(serviceURL, opts) {
   } catch (error) {
     error["function"] = "getFeatureService";
     if (opts.debug) logger.error(error.toString());
-    // throw new Error(error)
-    return false;
+    throw new Error(error);
   }
 }
 
@@ -627,6 +631,10 @@ function createJsonStream(options, opts) {
       inFeatures += 1;
       let json;
       try {
+        if (!chunk.geometry) {
+          throw new Error("Feature is missing geometry");
+        }
+
         if (opts.format === "json") {
           const props = chunk.attributes;
           const coords =
@@ -652,7 +660,7 @@ function createJsonStream(options, opts) {
         }
       } catch (err) {
         if (options.warnFn) {
-          options.warnFn(err, inFeatures, chunk);
+          options.warnFn(err, inFeatures - 1, chunk);
         }
         callback();
         return;
@@ -698,6 +706,8 @@ async function getFeatures(
   let idFieldObject = [];
   let hasErrors = false;
   let nbrFeatures = 0;
+  let featuresWithError = 0;
+  const exampleErrors = [];
 
   const jsonStart = `{"type": "FeatureCollection", "agolLayerId": ${id}, "features": [`;
 
@@ -713,16 +723,23 @@ async function getFeatures(
       afterAll: opts.pretty ? "\n]}" : "]}",
       separator: opts.pretty ? ",\n" : ",",
       indent: opts.pretty ? 2 : 0,
-      warnFn: (err, row, jsonObject) => {
+      warnFn: (err, index, feature) => {
         if (!opts.silent) {
-          spinner.warn(`record ${row} of ${layerName} is invalid`).start();
+          spinner.warn(`record ${index} of ${layerName} is invalid`).start();
         }
         if (opts.debug) {
           if (!opts.silent) spinner.stop();
-          logger.warn(`record ${row} of ${layerName} is invalid`);
+          logger.warn(`record ${index} of ${layerName} is invalid`);
           if (!opts.silent) spinner.start();
         }
-        hasErrors = true;
+        if (exampleErrors.length < 3) {
+          exampleErrors.push({
+            index,
+            feature,
+            error: err.message,
+          });
+        }
+        featuresWithError += 1;
       },
       geometryType: geometryType,
       renderer: renderer,
@@ -826,17 +843,13 @@ async function getFeatures(
 
       geojson = await queryAGOL(layerUrl, idField, ids.start, ids.end, opts, layerName);
 
-      if (
-        (!geojson || !geojson.features || !geojson.features.length || geojson.error) &&
-        ids.end > END
-      ) {
-        if (opts.debug) logger.info("finished downloading layers");
-        completed = true;
-      } else if (
-        (!geojson || !geojson.features || !geojson.features.length || geojson.error) &&
-        ids.end < END
-      ) {
-        throw new Error("Error with " + layerName + " " + ids.start + "-" + ids.end);
+      if (!geojson || !geojson.features || !geojson.features.length || geojson.error) {
+        if (ids.end > END) {
+          if (opts.debug) logger.info("finished downloading layers");
+          completed = true;
+        } else {
+          throw new Error("Error with " + layerName + " " + ids.start + "-" + ids.end);
+        }
       } else {
         if (geojson.features && geojson.features.length > 0) {
           // if (!opts.silent) spinner.start("Processing features " + ids.start + "-" + ids.end)
@@ -874,12 +887,26 @@ async function getFeatures(
 
   jsonInStream.end(); // signal no more data
 
+  // wait for output to finish before using the file
+  try {
+    await writeDonePromise;
+  } catch (error) {
+    hasErrors = true;
+    if (opts.debug) logger.error("Error in queryAGOL " + error.toString());
+  }
+
   if (!nbrFeatures) hasErrors = true;
 
   if (hasErrors) {
     if (fs.existsSync(filepath) && !opts.debug) fs.unlinkSync(filepath);
     spinner.fail(`Deleting ${filepath} due to errors`);
   } else {
+    const writtenFeatures = nbrFeatures - featuresWithError;
+
+    if (opts.debug && featuresWithError > 0) {
+      logger.warn(`Warning! There were ${nbrFeatures} total features: ${writtenFeatures} successful, ${featuresWithError} bad.`)
+    }
+
     if (opts.outputFormat.toLowerCase() !== "geojson") {
       const Gdal = await initGdalJs();
       try {
@@ -904,27 +931,33 @@ async function getFeatures(
           fs.writeFileSync(_path, _bytes);
           if (fs.existsSync(filepath)) fs.unlinkSync(filepath);
 
-          spinner.succeed(`Success! Wrote ${nbrFeatures} features to ${_path}`).start();
-          if (opts.debug) logger.debug(`Success! Wrote ${nbrFeatures} features to ${_path}`);
+          spinner.succeed(`Success! Wrote ${writtenFeatures} features to ${_path}`).start();
+          if (opts.debug) logger.debug(`Success! Wrote ${writtenFeatures} features to ${_path}`);
         }
       } catch (error) {
         spinner.warn(`Error converting geojson to ${opts.outputFormat}`).start();
         if (opts.debug) logger.debug(`Error converting geojson to ${opts.outputFormat}`);
       }
     } else {
-      spinner.succeed(`Success! Wrote ${nbrFeatures} features to ${filepath}`).start();
-      if (opts.debug) logger.debug(`Success! Wrote ${nbrFeatures} features to ${filepath}`);
+      spinner.succeed(`Success! Wrote ${writtenFeatures} features to ${filepath}`).start();
+      if (opts.debug) logger.debug(`Success! Wrote ${writtenFeatures} features to ${filepath}`);
     }
   }
 
-  try {
-    await writeDonePromise; // and wait for everything to finish
-  } catch (error) {
-    hasErrors = true;
-    if (opts.debug) logger.error("Error in queryAGOL " + error.toString());
-  }
+  return {hasErrors, nbrFeatures, featuresWithError, exampleErrors};
 }
 
+/**
+ * Download features from AGOL.
+ * The query is *inclusive* of both the start and end ID values.
+ * @param {*} url 
+ * @param {*} idField 
+ * @param {*} start 
+ * @param {*} end 
+ * @param {*} opts 
+ * @param {*} layerName 
+ * @returns 
+ */
 async function queryAGOL(url, idField, start, end, opts, layerName) {
   const query = `${url}query?where=${idField}+between+${start}+and+${end}&outSR=4326&outFields=*&f=${
     opts.format
@@ -955,11 +988,11 @@ function isFunction(fn) {
 
 async function getStartEnd(query, opts) {
   try {
-    const startRes = await fetch(query + "%20ASC&resultRecordCount=1&f=pjson", {
+    const startRes = await fetch(query + "%20ASC&resultRecordCount=1&f=json", {
       timeout: opts.timeout,
     });
     const startId = await startRes.json();
-    const endRes = await fetch(query + "%20DESC&resultRecordCount=1&f=pjson", {
+    const endRes = await fetch(query + "%20DESC&resultRecordCount=1&f=json", {
       timeout: opts.timeout,
     });
     const endId = await endRes.json();

--- a/tests/featureServiceToGeoJSON.test.js
+++ b/tests/featureServiceToGeoJSON.test.js
@@ -1,0 +1,342 @@
+jest.mock("node-fetch");
+jest.mock("fs", () => ({
+  createWriteStream: jest.fn(),
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  stat: jest.fn(),
+}));
+
+// Mock the ora spinner
+jest.mock("ora", () => {
+  const mockSpinner = {
+    start: jest.fn().mockImplementation(() => mockSpinner),
+    stop: jest.fn().mockImplementation(() => mockSpinner),
+    fail: jest.fn().mockImplementation(() => mockSpinner),
+    info: jest.fn().mockImplementation(() => mockSpinner),
+    warn: jest.fn().mockImplementation(() => mockSpinner),
+    succeed: jest.fn().mockImplementation(() => mockSpinner),
+    isSpinning: false,
+    text: "",
+  };
+
+  return jest.fn(() => mockSpinner);
+});
+
+const fs = require("fs");
+const fetch = require("node-fetch");
+const ora = require("ora");
+const { EventEmitter } = require("events");
+
+const { mockArcGISService } = require("./mockArcGISService");
+
+const { featureServiceToGeoJSON } = require("../lib/featureServiceToGeoJSON");
+
+describe("ora mock behavior", () => {
+  it("should return the mocked spinner instance", () => {
+    const spinner = ora();
+    expect(spinner).toBeDefined();
+    expect(typeof spinner.start).toBe("function");
+    expect(typeof spinner.succeed).toBe("function");
+
+    spinner.start();
+    expect(spinner.start).toHaveBeenCalled();
+
+    const instance = spinner.succeed("Test message");
+    expect(spinner.succeed).toHaveBeenCalledWith("Test message");
+    expect(instance).toBe(spinner);
+  });
+});
+
+describe("featureServiceToGeoJSON", () => {
+  let mockSpinner;
+  let mockStream;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSpinner = ora();
+
+    mockStream = new EventEmitter();
+    mockStream.buffer = [];
+    mockStream.write = jest.fn().mockImplementation((data) => {
+      mockStream.buffer.push(data);
+    });
+    mockStream.end = jest.fn().mockImplementation(() => {
+      // Simulate the stream finishing
+      setTimeout(() => mockStream.emit("finish"), 0);
+    });
+    mockStream.pipe = jest.fn();
+
+    fs.createWriteStream.mockReturnValue(mockStream);
+    fs.existsSync.mockReturnValue(true);
+    fs.mkdirSync.mockImplementation(() => {});
+    fs.stat.mockImplementation((_path, callback) => {
+      const mockStats = {
+        isDirectory: jest.fn(() => false),
+        isFile: jest.fn(() => true),
+      };
+      callback(null, mockStats);
+    });
+  });
+
+  it("should successfully read a single layer", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        geometryType: "esriGeometryPoint",
+        fields: [
+          { name: "label", type: "esriFieldTypeString", alias: "Label" },
+          { name: "OBJECTID", type: "esriFieldTypeOID", alias: "OBJECTID" },
+        ],
+        features: [
+          { attributes: { name: "A", OBJECTID: 1 }, geometry: { x: 0, y: 0 } },
+          { attributes: { name: "B", OBJECTID: 2 }, geometry: { x: 1, y: 1 } },
+        ],
+      },
+    ]);
+
+    const options = {
+      debug: true,
+      silent: true,
+      format: "geojson",
+      layers: true,
+    };
+
+    const result = await featureServiceToGeoJSON("https://example.com/FeatureServer", options);
+
+    expect(fetch).toHaveBeenCalled();
+    expect(fetch.mock.calls[0][0]).toBe('https://example.com/FeatureServer/?f=json');
+
+    expect(result.layers[0].nbrErrors).toBe(0);
+    expect(result.layers[0].nbrFeatures).toBe(2);
+
+    expect(mockStream.write).toHaveBeenCalled();
+    const output = mockStream.buffer.join("");
+    const parsedOutput = JSON.parse(output);
+    expect(parsedOutput.type).toBe("FeatureCollection");
+    expect(parsedOutput.features).toEqual([
+      {
+        type: "Feature",
+        geometry: { x: 0, y: 0 },
+        properties: { name: "A", OBJECTID: 1 },
+      },
+      {
+        type: "Feature",
+        geometry: { x: 1, y: 1 },
+        properties: { name: "B", OBJECTID: 2 },
+      },
+    ]);
+
+    // Validate spinner interactions
+    expect(mockSpinner.start).toHaveBeenCalled();
+    expect(mockSpinner.fail).not.toHaveBeenCalled();
+    expect(mockSpinner.succeed).toHaveBeenCalledWith("Success! Wrote 2 features to geojson-cache/layer1.geojson");
+    expect(mockSpinner.succeed).toHaveBeenCalledWith(
+      expect.stringMatching(/Wrote \d+ features/)
+    );
+  });
+
+  it("should process layers and flag features with missing geometry", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        geometryType: "esriGeometryPoint",
+        fields: [
+          { name: "label", type: "esriFieldTypeString", alias: "Label" },
+          { name: "OBJECTID", type: "esriFieldTypeOID", alias: "OBJECTID" },
+        ],
+        features: [
+          { attributes: { name: "A", OBJECTID: 1 }, geometry: { x: 0, y: 0 } },
+          { attributes: { name: "B", OBJECTID: 2 } }, // Missing geometry
+        ],
+      },
+    ]);
+
+    const result = await featureServiceToGeoJSON("https://example.com/FeatureServer", {});
+
+    expect(result.layers[0].nbrErrors).toBe(1);
+    expect(result.layers[0].nbrFeatures).toBe(2);
+    expect(result.layers[0].exampleErrors).toHaveLength(1);
+    expect(result.layers[0].exampleErrors[0]).toEqual({
+      index: 1,
+      feature: { type: "Feature", properties: { name: "B", OBJECTID: 2 } },
+      error: "Feature is missing geometry",
+    });
+  });
+
+  // TODO: this test fails!
+  // it.only("should page through features when the result exceeds the service maxRecordCount", async () => {
+  //   // TODO: mock maxRecordCount
+  //   mockArcGISService([
+  //     {
+  //       name: "Layer1",
+  //       geometryType: "esriGeometryPoint",
+  //       fields: [
+  //         { name: "label", type: "esriFieldTypeString", alias: "Label" },
+  //         { name: "id", type: "esriFieldTypeOID", alias: "OBJECTID" },
+  //       ],
+  //       maxRecordCount: 2,
+  //       features: [
+  //         { attributes: { label: "A", id: 1 }, geometry: { x: 0, y: 0 } },
+  //         { attributes: { label: "B", id: 2 }, geometry: { x: 1, y: 1 } },
+  //         { attributes: { label: "C", id: 3 }, geometry: { x: 2, y: 2 } },
+  //         { attributes: { label: "D", id: 4 }, geometry: { x: 3, y: 3 } },
+  //         { attributes: { label: "E", id: 5 }, geometry: { x: 4, y: 4 } },
+  //       ],
+  //     },
+  //   ]);
+
+  //   const result = await featureServiceToGeoJSON(
+  //     "https://example.com/FeatureServer",
+  //     {}
+  //   );
+
+  //   expect(result.layers[0].nbrErrors).toBe(0);
+  //   expect(result.layers[0].nbrFeatures).toBe(5);
+  // });
+
+  it("should handle services with no layers gracefully", async () => {
+    mockArcGISService();
+
+    const result = await featureServiceToGeoJSON("https://example.com/FeatureServer", {});
+
+    expect(result.layers).toHaveLength(0);
+    expect(mockSpinner.fail).toHaveBeenCalledWith("Fatal error, no layers found!");
+  });
+
+  it("should handle 400 errors gracefully", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: jest.fn().mockResolvedValue({ error: "Bad request" }),
+    });
+
+    const options = {
+      debug: true,
+      silent: true,
+    };
+
+    await expect(
+      featureServiceToGeoJSON("https://example.com/FeatureServer", options)
+    ).rejects.toThrow("Could not find feature service definition: Bad request");
+
+    expect(mockSpinner.fail).toHaveBeenCalledWith("Could not find feature service definition: Bad request");
+  });
+
+  it("should handle 404 errors gracefully", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: jest.fn().mockResolvedValue({ error: "Not found" }),
+    });
+
+    const options = {
+      debug: true,
+      silent: true,
+    };
+
+    await expect(
+      featureServiceToGeoJSON("https://example.com/FeatureServer", options)
+    ).rejects.toThrow("Could not find feature service definition: Not found");
+
+    expect(mockSpinner.fail).toHaveBeenCalledWith("Could not find feature service definition: Not found");
+  });
+
+  it("should handle 500 errors gracefully", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: jest.fn().mockResolvedValue({ error: "Internal server error" }),
+    });
+
+    const options = {
+      debug: true,
+      silent: true,
+    };
+
+    await expect(
+      featureServiceToGeoJSON("https://example.com/FeatureServer", options)
+    ).rejects.toThrow("Could not find feature service definition: Internal server error");
+
+    expect(mockSpinner.fail).toHaveBeenCalledWith("Could not find feature service definition: Internal server error");
+  });
+
+  // TODO: this test doesn't work, filtering layers doesn't remove them from the list,
+  // should they be removed?
+  // it("should skip layers based on filter options", async () => {
+  //   mockArcGISService([
+  //     {
+  //       name: "Layer1",
+  //       geometryType: "esriGeometryPoint",
+  //       fields: [
+  //         { name: "label", type: "esriFieldTypeString", alias: "Label" },
+  //         { name: "OBJECTID", type: "esriFieldTypeOID", alias: "OBJECTID" },
+  //       ],
+  //       features: [
+  //         { attributes: { name: "A", OBJECTID: 1 }, geometry: { x: 0, y: 0 } },
+  //         { attributes: { name: "B", OBJECTID: 2 }, geometry: { x: 1, y: 1 } },
+  //       ],
+  //     },
+  //     {
+  //       name: "ExcludedLayer",
+  //       geometryType: "esriGeometryPoint",
+  //       fields: [
+  //         { name: "label", type: "esriFieldTypeString", alias: "Label" },
+  //         { name: "OBJECTID", type: "esriFieldTypeOID", alias: "OBJECTID" },
+  //       ],
+  //       features: [
+  //         { attributes: { name: "C", OBJECTID: 3 }, geometry: { x: 2, y: 2 } },
+  //         { attributes: { name: "D", OBJECTID: 4 }, geometry: { x: 3, y: 3 } },
+  //       ],
+  //     },
+  //   ]);
+
+  //   const options = {
+  //     debug: true,
+  //     silent: true,
+  //     filter: "Layer1",
+  //   };
+
+  //   const result = await featureServiceToGeoJSON(
+  //     "https://example.com/FeatureServer",
+  //     options
+  //   );
+
+  //   expect(result.layers.length).toBe(1);
+  //   expect(result.layers[0].name).toBe("Layer1");
+  //   expect(mockSpinner.info).toHaveBeenCalledWith("Skipping layer: ExcludedLayer");
+  // });
+
+  it("should throw an error for non-FeatureServer/MapServer URLs", async () => {
+    const options = {
+      debug: true,
+      silent: true,
+    };
+
+    await expect(
+      featureServiceToGeoJSON("https://example.com/InvalidServer", options)
+    ).rejects.toThrow("Error, this script only works with FeatureServer and MapServer services");
+
+    expect(mockSpinner.fail).not.toHaveBeenCalled();
+  });
+
+  it("should handle unexpected server response content gracefully", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue("text/html"),
+      },
+      json: jest.fn().mockImplementation(() => {
+        throw new Error("Unexpected token < in JSON");
+      }),
+    });
+
+    const options = {
+      debug: true,
+      silent: true,
+    };
+
+    await expect(
+      featureServiceToGeoJSON("https://example.com/FeatureServer", options)
+    ).rejects.toThrow("Error: Unexpected token < in JSON");
+  });
+});

--- a/tests/mockArcGISService.js
+++ b/tests/mockArcGISService.js
@@ -1,0 +1,210 @@
+const fetch = require("node-fetch");
+
+function mockArcGISService(layers = [], tables = []) {
+  const mockResponses = new Map();
+
+  mockResponses.set("layers", {
+    layers: layers.map((layer, index) => {
+      const { features, ...layerWithoutFeatures } = layer; // Exclude features
+      return { ...layerWithoutFeatures, id: index };
+    }),
+  });
+
+  layers.forEach((layer, index) => {
+    const features = layer.features;
+    const maxRecordCount = layer.maxRecordCount || 1000;
+
+    const oidField = layer.fields.find((field) => field.type === "esriFieldTypeOID")?.name;
+    if (!oidField) {
+      throw new Error(`Layer ${layer.name} does not have an Object ID field.`);
+    }
+
+    const featureResponse = { ...layer };
+
+    const metadataResponse = { ...featureResponse };
+    delete metadataResponse.features;
+
+    mockResponses.set(`layer${index}-metadata`, metadataResponse);
+    mockResponses.set(`layer${index}-query`, (queryParams, format) => {
+      const { where, returnIdsOnly, orderByFields, resultRecordCount, returnCountOnly } = queryParams;
+      let filteredFeatures = [...features];
+
+      if (where) {
+        const normalizedWhere = where.toLowerCase();
+
+        if (normalizedWhere === "1=1") {
+          // all features
+        } else {
+          // Handle `oidField between x and y`
+          const oidCondition = new RegExp(`${oidField.toLowerCase()}\\s+between\\s+(\\d+)\\s+and\\s+(\\d+)`, "i");
+          const betweenMatch = normalizedWhere.match(oidCondition);
+          if (betweenMatch) {
+            const lowerBound = parseInt(betweenMatch[1], 10);
+            const upperBound = parseInt(betweenMatch[2], 10);
+            filteredFeatures = filteredFeatures.filter(
+              (feature) =>
+                feature.attributes[oidField] >= lowerBound &&
+                feature.attributes[oidField] <= upperBound
+            );
+          }
+
+          // Handle other conditions like "field > value"
+          const conditionMatch = normalizedWhere.match(/(\w+)\s*([><=]+)\s*(\d+)/);
+          if (conditionMatch) {
+            const field = conditionMatch[1];
+            const operator = conditionMatch[2];
+            const value = parseInt(conditionMatch[3], 10);
+
+            filteredFeatures = filteredFeatures.filter((feature) => {
+              const featureField = Object.keys(feature.attributes).find(
+                (key) => key.toLowerCase() === field
+              );
+              if (!featureField) return false;
+
+              const fieldValue = feature.attributes[featureField];
+              if (operator === ">") return fieldValue > value;
+              if (operator === "<") return fieldValue < value;
+              if (operator === "=" || operator === "==") return fieldValue === value;
+              return false;
+            });
+          }
+        }
+      }
+
+      if (returnCountOnly === "true") {
+        return { count: filteredFeatures.length };
+      }
+
+      if (orderByFields) {
+        const [fieldRaw, directionRaw] = orderByFields.split(" ");
+        const field = fieldRaw?.toLowerCase();
+        const direction = directionRaw?.toUpperCase();
+
+        filteredFeatures.sort((a, b) => {
+          const fieldA = Object.keys(a.attributes).find(
+            (key) => key.toLowerCase() === field
+          );
+          const fieldB = Object.keys(b.attributes).find(
+            (key) => key.toLowerCase() === field
+          );
+
+          if (!fieldA || !fieldB) return 0;
+
+          if (direction === "ASC") {
+            return a.attributes[fieldA] - b.attributes[fieldB];
+          } else if (direction === "DESC") {
+            return b.attributes[fieldB] - a.attributes[fieldA];
+          }
+          return 0;
+        });
+      }
+
+      const limit = resultRecordCount
+        ? Math.min(parseInt(resultRecordCount, 10), maxRecordCount)
+        : maxRecordCount;
+
+      filteredFeatures = filteredFeatures.slice(0, limit);
+
+      if (returnIdsOnly) {
+        return {
+          objectIdFieldName: oidField,
+          objectIds: filteredFeatures.map((feature) => feature.attributes[oidField]),
+        };
+      }
+
+      if (format === "geojson") {
+        return {
+          type: "FeatureCollection",
+          features: filteredFeatures.map((feature) => ({
+            type: "Feature",
+            geometry: feature.geometry,
+            properties: feature.attributes,
+          })),
+        };
+      }
+
+      return { features: filteredFeatures };
+    });
+  });
+
+  tables.forEach((table, index) => {
+    mockResponses.set(`table${index}`, { features: table.features });
+  });
+
+  // Mock the fetch function
+  fetch.mockImplementation((url) => {
+    let key;
+    let dynamicResponse;
+
+    // console.log(`Mock fetch request: ${url}`);
+
+    const queryParams = new URLSearchParams(url.split("?")[1]);
+
+    const format = queryParams.get("f");
+    if (format !== "json" && format !== "pjson" && format !== "geojson") {
+      return Promise.resolve({
+        ok: false,
+        status: 400,
+        json: jest.fn().mockResolvedValue({
+          error: "Invalid format for testing. Supported formats are f=json, f=pjson, or f=geojson.",
+        }),
+        headers: {
+          get: jest.fn().mockReturnValue("application/json"),
+        },
+      });
+    }
+
+    if (url.match(/FeatureServer\/?\?f=(?:p?json|geojson)$/)) {
+      key = "layers";
+    } else if (url.match(/FeatureServer\/(\d+)\/\?f=(?:p?json|geojson)$/)) {
+      const match = url.match(/FeatureServer\/(\d+)\/\?f=(?:p?json|geojson)$/);
+      const layerId = match[1];
+      key = `layer${layerId}-metadata`;
+    } else if (url.match(/FeatureServer\/(\d+)\/query/)) {
+      const match = url.match(/FeatureServer\/(\d+)\/query/);
+      const layerId = match[1];
+      const where = queryParams.get("where");
+      const returnIdsOnly = queryParams.get("returnIdsOnly") === "true";
+      const orderByFields = queryParams.get("orderByFields");
+      const resultRecordCount = queryParams.get("resultRecordCount");
+      const returnCountOnly = queryParams.get("returnCountOnly");
+
+      key = `layer${layerId}-query`;
+      dynamicResponse = mockResponses.get(key)?.({
+        where,
+        returnIdsOnly,
+        orderByFields,
+        resultRecordCount,
+        returnCountOnly,
+      }, format);
+    }
+
+    // Return the appropriate mock response
+    const response = dynamicResponse || mockResponses.get(key);
+    if (response) {
+      // console.log(`Mock response: ${JSON.stringify(response)}`);
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue(response),
+        headers: {
+          get: jest.fn().mockReturnValue(
+            format === "geojson" ? "application/geo+json" : "application/json"
+          ),
+        },
+      });
+    }
+
+    // Fallback for unrecognized requests
+    return Promise.resolve({
+      ok: false,
+      status: 404,
+      json: jest.fn().mockResolvedValue({ error: "Not Found" }),
+      headers: {
+        get: jest.fn().mockReturnValue("application/json"),
+      },
+    });
+  });
+}
+
+module.exports = { mockArcGISService };

--- a/tests/mockArcGISService.test.js
+++ b/tests/mockArcGISService.test.js
@@ -1,0 +1,361 @@
+const { mockArcGISService } = require("./mockArcGISService");
+const fetch = require("node-fetch");
+
+jest.mock("node-fetch");
+
+describe("mockArcGISService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 400 for unsupported formats", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "objectId", type: "esriFieldTypeOID" },
+        ],
+        features: [{ attributes: { objectId: 1 } }],
+      },
+    ]);
+
+    const invalidFormatQuery = "https://example.com/FeatureServer/0/query?where=1%3D1&f=xml";
+    const res = await fetch(invalidFormatQuery);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid format for testing. Supported formats are f=json, f=pjson, or f=geojson.");
+  });
+
+  it("should handle valid formats correctly", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "objectId", type: "esriFieldTypeOID" },
+        ],
+        features: [{ attributes: { objectId: 1 } }],
+      },
+    ]);
+
+    const validQuery = "https://example.com/FeatureServer/0/query?where=1%3D1&f=json";
+    const res = await fetch(validQuery);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.features[0].attributes.objectId).toBe(1);
+  });
+
+  it("should handle metadata requests for a specific layer", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "objectId", type: "esriFieldTypeOID" },
+        ],
+        features: [],
+      },
+    ]);
+
+    const query = "https://example.com/FeatureServer/0/?f=pjson";
+    const res = await fetch(query);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.name).toBe("Layer1");
+  });
+
+  it("should handle feature queries for a specific layer", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "objectId", type: "esriFieldTypeOID" },
+        ],
+        features: [{ attributes: { objectId: 1 }, geometry: { x: 0, y: 0 } }],
+      },
+    ]);
+
+    const query = "https://example.com/FeatureServer/0/query?f=pjson&where=1=1";
+    const res = await fetch(query);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.features.length).toBe(1);
+    expect(data.features[0].attributes.objectId).toBe(1);
+  });
+
+  it("should return valid GeoJSON when f=geojson is requested", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [{ name: "OBJECTID", type: "esriFieldTypeOID" }],
+        features: [
+          { attributes: { OBJECTID: 1 }, geometry: { x: 0, y: 0 } },
+          { attributes: { OBJECTID: 2 }, geometry: { x: 1, y: 1 } },
+        ],
+      },
+    ]);
+
+    const query = "https://example.com/FeatureServer/0/query?where=1=1&f=geojson";
+    const res = await fetch(query);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.type).toBe("FeatureCollection");
+    expect(data.features.length).toBe(2);
+    expect(data.features).toEqual([
+      {
+        type: "Feature",
+        geometry: { x: 0, y: 0 },
+        properties: { OBJECTID: 1 },
+      },
+      {
+        type: "Feature",
+        geometry: { x: 1, y: 1 },
+        properties: { OBJECTID: 2 },
+      },
+    ]);
+  });
+
+  it("should handle feature count queries", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "objectId", type: "esriFieldTypeOID" },
+        ],
+        features: [
+          { attributes: { objectId: 1 }, geometry: { x: 0, y: 0 } },
+          { attributes: { objectId: 2 }, geometry: { x: 1, y: 1 } },
+          { attributes: { objectId: 3 }, geometry: { x: 2, y: 2 } },
+        ],
+      },
+    ]);
+
+    const query =
+      "https://example.com/FeatureServer/0/query?f=json&where=1=1&returnCountOnly=true";
+    const res = await fetch(query);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.count).toBe(3);
+  });
+
+  it("should handle returnIdsOnly queries", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "OBJECTID", type: "esriFieldTypeOID" },
+        ],
+        features: [
+          { attributes: { OBJECTID: 104330 }, geometry: { x: 0, y: 0 } },
+          { attributes: { OBJECTID: 104331 }, geometry: { x: 1, y: 1 } },
+          { attributes: { OBJECTID: 104332 }, geometry: { x: 2, y: 2 } },
+        ],
+      },
+    ]);
+
+    const query =
+      "https://example.com/FeatureServer/0/query?where=1%3D1&returnIdsOnly=true&f=json";
+    const res = await fetch(query);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.objectIdFieldName).toBe("OBJECTID");
+    expect(data.objectIds).toEqual([104330, 104331, 104332]);
+  });
+
+  it("should respect the resultRecordCount parameter", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "OBJECTID", type: "esriFieldTypeOID" },
+        ],
+        features: [
+          { attributes: { OBJECTID: 104330 }, geometry: { x: 0, y: 0 } },
+          { attributes: { OBJECTID: 104331 }, geometry: { x: 1, y: 1 } },
+          { attributes: { OBJECTID: 104332 }, geometry: { x: 2, y: 2 } },
+        ],
+      },
+    ]);
+
+    const query =
+      "https://example.com/FeatureServer/0/query?where=1%3D1&returnIdsOnly=true&resultRecordCount=2&f=json";
+    const res = await fetch(query);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.objectIds).toEqual([104330, 104331]);
+  });
+
+  it("should respect maxRecordCount for each layer", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [{ name: "objectId", type: "esriFieldTypeOID" }],
+        features: Array.from({ length: 15 }, (_, i) => ({
+          attributes: { objectId: i + 1 },
+          geometry: { x: i, y: i },
+        })),
+        maxRecordCount: 5,
+      },
+      {
+        name: "Layer2",
+        fields: [{ name: "objectId", type: "esriFieldTypeOID" }],
+        features: Array.from({ length: 20 }, (_, i) => ({
+          attributes: { objectId: i + 1 },
+          geometry: { x: i, y: i },
+        })),
+        maxRecordCount: 10,
+      },
+    ]);
+  
+    const layer1Query = "https://example.com/FeatureServer/0/query?where=1%3D1&f=json";
+    const layer1Res = await fetch(layer1Query);
+    const layer1Data = await layer1Res.json();
+    expect(layer1Res.status).toBe(200);
+    expect(layer1Data.features.length).toBe(5);
+  
+    const layer2Query = "https://example.com/FeatureServer/1/query?where=1%3D1&f=json";
+    const layer2Res = await fetch(layer2Query);
+    const layer2Data = await layer2Res.json();
+    expect(layer2Res.status).toBe(200);
+    expect(layer2Data.features.length).toBe(10);
+  });
+
+  it("should handle ascending and descending ID queries", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "objectId", type: "esriFieldTypeOID" },
+        ],
+        features: [
+          { attributes: { objectId: 1 }, geometry: { x: 0, y: 0 } },
+          { attributes: { objectId: 2 }, geometry: { x: 1, y: 1 } },
+          { attributes: { objectId: 3 }, geometry: { x: 2, y: 2 } },
+        ],
+      },
+    ]);
+
+    // Simulate ascending query
+    const ascQuery =
+      "https://example.com/FeatureServer/0/query?where=objectId+>+-1&returnIdsOnly=true&orderByFields=objectId%20ASC&resultRecordCount=1&f=pjson";
+    const ascRes = await fetch(ascQuery);
+    const ascData = await ascRes.json();
+    expect(ascRes.status).toBe(200);
+    expect(ascData.objectIds).toEqual([1]);
+
+    // Simulate descending query
+    const descQuery =
+      "https://example.com/FeatureServer/0/query?where=objectId+>+-1&returnIdsOnly=true&orderByFields=objectId%20DESC&resultRecordCount=1&f=pjson";
+    const descRes = await fetch(descQuery);
+    const descData = await descRes.json();
+    expect(descRes.status).toBe(200);
+    expect(descData.objectIds).toEqual([3]);
+  });
+
+  it("should handle between ID queries", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "objectId", type: "esriFieldTypeOID" },
+          { name: "name", type: "esriFieldTypeString" },
+        ],
+        features: [
+          { attributes: { objectId: 1, name: "Feature1" }, geometry: { x: 0, y: 0 } },
+          { attributes: { objectId: 2, name: "Feature2" }, geometry: { x: 1, y: 1 } },
+          { attributes: { objectId: 3, name: "Feature3" }, geometry: { x: 2, y: 2 } },
+        ],
+      },
+    ]);
+
+    const betweenQuery =
+      "https://example.com/FeatureServer/0/query?where=objectId+between+1+and+2&f=json";
+    const res = await fetch(betweenQuery);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.features.length).toBe(2);
+    expect(data.features.map((f) => f.attributes.objectId)).toEqual([1, 2]);
+  });
+
+  it("should handle case-insensitive field names in orderByFields", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "ObjectID", type: "esriFieldTypeOID" },
+          { name: "name", type: "esriFieldTypeString" },
+        ],
+        features: [
+          { attributes: { ObjectID: 3, name: "Feature3" }, geometry: { x: 0, y: 0 } },
+          { attributes: { ObjectID: 1, name: "Feature1" }, geometry: { x: 1, y: 1 } },
+          { attributes: { ObjectID: 2, name: "Feature2" }, geometry: { x: 2, y: 2 } },
+        ],
+      },
+    ]);
+
+    const query =
+      "https://example.com/FeatureServer/0/query?where=ObjectID+>+-1&returnIdsOnly=true&orderByFields=objectid%20ASC&f=json";
+    const res = await fetch(query);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.objectIds).toEqual([1, 2, 3]);
+  });
+
+  it("should handle case-insensitive field names in where clause", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "OBJECTID", type: "esriFieldTypeOID" },
+          { name: "name", type: "esriFieldTypeString" },
+        ],
+        features: [
+          { attributes: { OBJECTID: 1, name: "Feature1" }, geometry: { x: 0, y: 0 } },
+          { attributes: { OBJECTID: 2, name: "Feature2" }, geometry: { x: 1, y: 1 } },
+          { attributes: { OBJECTID: 3, name: "Feature3" }, geometry: { x: 2, y: 2 } },
+        ],
+      },
+    ]);
+
+    const query =
+      "https://example.com/FeatureServer/0/query?where=objectid > 1&f=json";
+    const res = await fetch(query);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.features.length).toBe(2); // Matches OBJECTID 2 and 3
+    expect(data.features.map((f) => f.attributes.OBJECTID)).toEqual([2, 3]);
+  });
+
+  it("should handle mixed-case field names in where clause", async () => {
+    mockArcGISService([
+      {
+        name: "Layer1",
+        fields: [
+          { name: "OBJECTID", type: "esriFieldTypeOID" },
+          { name: "name", type: "esriFieldTypeString" },
+        ],
+        features: [
+          { attributes: { OBJECTID: 1, name: "Feature1" }, geometry: { x: 0, y: 0 } },
+          { attributes: { OBJECTID: 2, name: "Feature2" }, geometry: { x: 1, y: 1 } },
+          { attributes: { OBJECTID: 3, name: "Feature3" }, geometry: { x: 2, y: 2 } },
+        ],
+      },
+    ]);
+
+    const query =
+      "https://example.com/FeatureServer/0/query?where=ObJeCtId between 1 and 2&f=json";
+    const res = await fetch(query);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.features.length).toBe(2); // Matches OBJECTID 1 and 2
+    expect(data.features.map((f) => f.attributes.OBJECTID)).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
This emerged from a need to better handle source features that are missing a geometry. Currently, the package provides the number of features in the source service, but does not provide a way to see how many unusable features were encountered or the number that were successfully cached. I got carried away and also added additional unit testing to make sure the operation was not impacted.

## Changes
1. GDAL isn't initialized unless it is being used.
2. The `featureServiceToGeoJSON` function error handling is standardized, from `return null` or `return false` or `throw` to always just `throw`.
3. The `featureServiceToGeoJSON` return type was changed from an array or object to just object.
4. In addition to `count` which is the actual service count, the function now provides:
  - `nbrFeatures` for the total number of features downloaded.
  - `nbrErrors` for the features that were not output because of a handling error.
  - `exampleErrors` lists the first 3 errors that were encountered when parsing features, to help with debugging.
5. `logger.error` outputs the actual exception stack for better debugging.
6. The `await` for the writing to complete was moved to before the file is first accessed.
7. Adds a server mock for an ArcGIS feature service, with tests of the mock's responses.
8. Adds tests for various feature caching scenarios using the mock server.

Note that there are a couple of failing tests (commented out) that we may want to get the package to pass, depending on how it should work.

1. Caching doesn't seem to work if the service has a record limit less than 1000.
2. Layer filtering doesn't remove the layers from the returned list, should it?